### PR TITLE
Исправлена ошибка с отображением окна на экранах размера FullHd

### DIFF
--- a/simple_editor.py
+++ b/simple_editor.py
@@ -3026,7 +3026,7 @@ if __name__ == "__main__":
     sg.Tab(get_locale('mediafiles') ,tab_layout_mediafiles,key='tab_layout_mediafiles'),
     sg.Tab(get_locale('common_handlers') ,tab_layout_common_handlers,key='tab_layout_common_handlers'),
     sg.Tab(get_locale('generators') ,tab_layout_classes,key='tab_layout_classes')
-    ]],key='main_tabs',enable_events=True,expand_x=True)]
+    ]],key='main_tabs',enable_events=True,expand_x=True, size=(None, 250))]
 
 
 


### PR DESCRIPTION
На экране FullHD на Windows в предыдущей ветки не было видно части окна снизу. В данном коммите исправлен размер layout_configuration_options , что позволяет видеть всю информацию в окне.

Было:
https://sun9-57.userapi.com/impg/ZUBbP5ajW1ZUJkqN3Y4yg1OyPYwgL_iqdRL2Bw/2e9_HLo2Sew.jpg?size=1920x1080&quality=95&sign=8e73c9610b389d8fbebfe5e40c2d570f&type=album
Стало:
https://sun9-66.userapi.com/impg/K7i2e7mJ82TWNkOGNi0Oh_lncim8t2hyIjIN7g/M87xNHCceZ8.jpg?size=1920x1080&quality=95&sign=c432b700425d84e7a7961b7e29e18ed7&type=album